### PR TITLE
No se muestran archivos estáticos

### DIFF
--- a/pycones/settings.py
+++ b/pycones/settings.py
@@ -8,10 +8,10 @@ PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
 
 DEBUG = not (os.getenv("DJANGO_ENV", "devel") == "production")
-TEMPLATE_DEBUG = DEBUG
+TEMPLATE_DEBUG = True
 
 # tells Pinax to serve media through the staticfiles app.
-SERVE_MEDIA = DEBUG
+SERVE_MEDIA = True
 
 INTERNAL_IPS = [
     "127.0.0.1",
@@ -211,7 +211,7 @@ LOGIN_URL = "/account/login/" # @@@ any way this can be a url name?
 
 EMAIL_CONFIRMATION_DAYS = 2
 EMAIL_DEBUG = DEBUG
-if not DEBUG:
+if not EMAIL_DEBUG:
     EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
     EMAIL_HOST = os.getenv('EMAIL_HOST')
     EMAIL_PORT = os.getenv('EMAIL_PORT')

--- a/pycones/settings.py
+++ b/pycones/settings.py
@@ -217,7 +217,7 @@ if not DEBUG:
     EMAIL_PORT = os.getenv('EMAIL_PORT')
     EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER')
     EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD')
-    EMAIL_USE_TLS = os.getenv('EMAIL_USE_TLS', False)
+    EMAIL_USE_TLS = bool(os.getenv('EMAIL_USE_TLS', False))
 else:
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 


### PR DESCRIPTION
He desplegado los cambios que hemos discutido en #14 pero ahora los ficheros estáticos no cargan. Creyendo que tenía algo que ver con las líneas 11 y 14 de settings.py las he cambiado pero no ha funcionado. Adjunto los cambios que he hecho fuera de la rama master.

Ahora mismo la web no muestra imágenes ni CSS; pensando que sería un problema rápido lo he dejado así pero si consideráis puedo revertir a la última versión que funcionó.
